### PR TITLE
remove a mudança de cor quando o item é colocado no local correto

### DIFF
--- a/custom/style.css
+++ b/custom/style.css
@@ -16,7 +16,7 @@ li {	list-style-type:none;
 		padding:5px; 
 		font-size:11px;
 		cursor:move; 
-		background:#d3d3d3; 
+		background:#e7e7e7; 
 		text-shadow:1px 1px 1px #FFF;
 }
 li:hover { background:#FFF; 

--- a/custom/ui.js
+++ b/custom/ui.js
@@ -965,7 +965,7 @@ if (window.Node && Node.prototype && !Node.prototype.contains) {
 				if($(self.element).attr('id')==$(self.element).parent().attr('id'))
 				{
 					$(self.element).find('.correct').remove();
-					$(self.element).css('background','#E7E7E7');
+					// $(self.element).css('background','#E7E7E7');
 				}
 				
 				//Check sequance

--- a/index.htm
+++ b/index.htm
@@ -115,7 +115,7 @@
 
             $('#0').append(list).shuffle();
             $('#0').find('.correct').each(function(){
-              $(this).parent().css('background','#E7E7E7');
+              // $(this).parent().css('background','#E7E7E7');
               $(this).remove();
             });
             $('#r').remove();

--- a/item_procap.json
+++ b/item_procap.json
@@ -765,7 +765,7 @@
                                     "nome": "Expansão da rede bancária e criação de bancos regionais."
                                 },
                                 {
-                                    "nome": "Criação da Sumoc (1945) como precursor do Banco Central."
+                                    "nome": "Criação da Sumoc (XXX) como precursor do Banco Central."
                                 },
                                 {
                                     "nome": "Banco do Brasil atuava como banco central de fato."
@@ -779,16 +779,16 @@
                             "nome": "Das reformas de 1964-1965 até 1988",
                             "itens": [
                                 {
-                                    "nome": "Lei 4.595/1964: Criou o Banco Central do Brasil (BCB) e o Conselho Monetário Nacional (CMN)."
+                                    "nome": "Lei X.XXX/XXXX: Criou o Banco Central do Brasil (BCB) e o Conselho Monetário Nacional (CMN)."
                                 },
                                 {
-                                    "nome": "Lei 4.380/1964: Criou o Sistema Financeiro da Habitação (SFH)."
+                                    "nome": "Lei X.XXX/XXXX: Criou o Sistema Financeiro da Habitação (SFH)."
                                 },
                                 {
-                                    "nome": "Lei 4.728/1965: Regulamentou o mercado de capitais."
+                                    "nome": "Lei X.XXX/XXXX: Regulamentou o mercado de capitais."
                                 },
                                 {
-                                    "nome": "Lei 6.385/1976: Criou a CVM para fiscalizar valores mobiliários."
+                                    "nome": "Lei X.XXX/XXXX: Criou a CVM para fiscalizar valores mobiliários."
                                 },                               
                                 {
                                     "nome": "Expansão do mercado financeiro e aumento da concentração bancária."
@@ -805,7 +805,7 @@
                                     "nome": "Criação dos bancos múltiplos, permitindo atuação em diversos segmentos."
                                 },
                                 {
-                                    "nome": "Constituição de 1988 eliminou o sistema de cartas patentes, facilitando a entrada de novas instituições."
+                                    "nome": "Eliminou o sistema de cartas patentes, facilitando a entrada de novas instituições."
                                 }                            
                             ]
                         },
@@ -813,16 +813,16 @@
                             "nome": "De 1994 aos dias atuais",
                             "itens": [
                                 {
-                                    "nome": "Plano Real (1994): Redução da inflação revelou ineficiências do setor financeiro."
+                                    "nome": "Plano Real (XXXX): Redução da inflação revelou ineficiências do setor financeiro."
                                 },
                                 {
-                                    "nome": "Crise bancária levou à criação do Proer (1995) e do Proes (1996) para reestruturação do SFN."
+                                    "nome": "Crise bancária levou à criação do Proer (XXXX) e do Proes (XXXX) para reestruturação do SFN."
                                 },
                                 {
                                     "nome": "Fundo Garantidor de Crédito (FGC): Criado para proteger depositantes."
                                 },
                                 {
-                                    "nome": "Lei 9.447/1997: Ampliou os poderes do Banco Central e reforçou a fiscalização."
+                                    "nome": "Lei X.XXX/XXXX: Ampliou os poderes do Banco Central e reforçou a fiscalização."
                                 }                            
                             ]
                         }


### PR DESCRIPTION
=====Remoção de datas====

Um dos exercícios é de posicionar eventos dentro de um período histórico
Mas as opções estavam com datas ou número de leis, escondi esses dados para não dar a resposta do exercício

=====Bug de cores=====

Bug estava revelando a resposta correta

Ocorre porque: pq tem uma funcao q muda a cor quando o card vai pra pilha correta

Porque essa função existe: pra quando você pede pra mostrar o resultado, você possa trocar o errado de coluna e ele ficar cinza

Porque isso é um problema: pq da maneira q ta feito em cima do css, o card vai se comportar diferente ao ir pra coluna correta
( se voce colocar um card em uma coluna correta e outro em uma coluna errada o hover do mouse vai entregar se a repsosta ta certa ou nao)

Correção nesse pull request: remove essa mudança de cor pra quando ele entra na coluna correta